### PR TITLE
feat: use tailscale ssh for pulumi remote command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,12 @@ jobs:
         run: |
             export UV_PROJECT_ENVIRONMENT="${pythonLocation}"
             uv sync --frozen
+      - name: Connect Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd
       - name: Pulumi Up CICD Stack
         uses: pulumi/actions@v6
         with:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ def root() -> HTMLResponse:
             <title>PyPack Trends</title>
         </head>
         <body>
-            <h3>PyPack Trends 🐍 coming soon...</h3>
+            <h3>PyPack Trends 🐍 coming soon!</h3>
         </body>
     </html>
     """

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -100,18 +100,18 @@ if settings.STACK_NAME == "cicd":
     remote_command = command.remote.Command(
         "remote-command",
         connection=command.remote.ConnectionArgs(
-            host=droplet.ipv4_address,
-            user="root",
-            private_key=ssh_key.private_key_pem,
+            host=droplet.name,
+            user=settings.VPS_USERNAME,
         ),
         create="""
             cd /opt/pypacktrends/infra
-            git pull
-            uv run pulumi up --stack prod --refresh --yes
+            sudo git pull
+            sudo uv run pulumi up --stack prod --refresh --yes
         """,
         environment={
             "PULUMI_ACCESS_TOKEN": settings.PULUMI_ACCESS_TOKEN,
         },
+        opts=pulumi.ResourceOptions(depends_on=[caddy_image, backend_image]),
     )
     pulumi.export("remote-command:stdout", remote_command.stdout)
     pulumi.export("remote-command:stderr", remote_command.stderr)

--- a/infra/components.py
+++ b/infra/components.py
@@ -94,6 +94,10 @@ class DockerImageComponent(pulumi.ComponentResource):  # type: ignore
 
     def use_remote_image(self) -> docker.RemoteImage:
         registry_image = docker.get_registry_image(name=self.image_tag)
+        pulumi.export(
+            f"registry-image-{self.service_name}:sha256-digest",
+            registry_image.sha256_digest,
+        )
         return docker.RemoteImage(
             self.docker_build_image_config.get("resource_name"),
             name=registry_image.name,


### PR DESCRIPTION
## What kind of change does this PR introduce?
This feature removes the need to provide pivate key in the pulumi remote a command because it relies on the connecting node to be on the tailnet. This means I needed to update the CD github action to authenticate before running pulumi up on the cicd stack.

Last deploy, I also had issues where the new images where not pulled and containers were not restarted even though the image digest changed. I made it so the remote command is dependent on the image resources to ensure it's executed after the images are published to ghcr.io
