### PR TITLE
feat: update caddy file

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -2,4 +2,11 @@
 	reverse_proxy {$BACKEND_SERVICE_NAME}:{$BACKEND_PORT} {
 		header_down Strict-Transport-Security max-age=31536000;
 	}
+	handle_errors {
+		respond "{err.status_code} {err.status_text}"
+	}
+}
+
+www.{$DOMAIN} {
+	redir https://{$DOMAIN}{uri}
 }

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -161,7 +161,6 @@ if settings.STACK_NAME in ["dev", "prod"]:
         ports=[
             docker.ContainerPortArgs(
                 internal=settings.BACKEND_SERVICE_PORT,
-                external=settings.BACKEND_SERVICE_PORT,
             )
         ],
         network_mode="bridge",

--- a/infra/components.py
+++ b/infra/components.py
@@ -101,6 +101,6 @@ class DockerImageComponent(pulumi.ComponentResource):  # type: ignore
         return docker.RemoteImage(
             self.docker_build_image_config.get("resource_name"),
             name=registry_image.name,
-            keep_locally=True,
+            force_remove=True,
             pull_triggers=[registry_image.sha256_digest],
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Caddy file now includes a redirect for people accessing www.pypacktrends.com to go to pypacktrends.com
- I got ride of the keep locally flag and added force remove on the docker remote image. I am having issues with pulumi properly deploying changes to docker remote images. It correctly detects the change in remote image digest which is defined as a pull trigger and shows the right changes that need to be made but doesn't pull the image and restart the container. I suspect it could be something caused by this flag so I also added the `force_remove` as well to clean up unused old containers.
- Also docker will modify your iptables which will bypass ufw rules. This was making it so port 8000 was exposed to the internet. I have removed the external port from the container definition. Here was the command I run to detect iptable changes by docker
```
sudo iptables -S
sudo iptables -L DOCKER -n -v
```

### Additional Context
```
https://app.pulumi.com/TylerHillery/pypacktrends/prod/previews/f4c41d97-b0ea-4f5d-8e85-2419ab0ad91c

     Type                         Name                  Plan        Info
     pulumi:pulumi:Stack          pypacktrends-prod
 +-  ├─ docker:index:RemoteImage  docker-image-backend  replace     [diff: ~pullTriggers]
 +-  └─ docker:index:Container    container-backend     replace     [diff: ~image]

Resources:
    +-2 to replace
    8 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:prod::pypacktrends::pulumi:pulumi:Stack::pypacktrends-prod]
    ++docker:index/remoteImage:RemoteImage: (create-replacement)
        [id=sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0ghcr.io/tylerhillery/pypacktrends/backend:latest]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/remoteImage:RemoteImage::docker-image-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]
      ~ pullTriggers: [
          ~ [0]: "sha256:5fb359f8c60eab25e500f060926420923ba854d7c57f0dcaa4915cb700ea15cb" => "sha256:f78a14ca8b23c3e3a8230a95c2b72fadc398635917e923059d1b5e3137c82e6b"
        ]
    +-docker:index/remoteImage:RemoteImage: (replace)
        [id=sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0ghcr.io/tylerhillery/pypacktrends/backend:latest]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/remoteImage:RemoteImage::docker-image-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]
      ~ pullTriggers: [
          ~ [0]: "sha256:5fb359f8c60eab25e500f060926420923ba854d7c57f0dcaa4915cb700ea15cb" => "sha256:f78a14ca8b23c3e3a8230a95c2b72fadc398635917e923059d1b5e3137c82e6b"
        ]
    --docker:index/container:Container: (delete-replaced)
        [id=78beacd7533ecc8ed8e052b5f13b95434c0f6f25e5f90c8d6f5951cd1cdce617]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/container:Container::container-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]
    +-docker:index/container:Container: (replace)
        [id=78beacd7533ecc8ed8e052b5f13b95434c0f6f25e5f90c8d6f5951cd1cdce617]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/container:Container::container-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]
      ~ image: "sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0" => output<string>
    ++docker:index/container:Container: (create-replacement)
        [id=78beacd7533ecc8ed8e052b5f13b95434c0f6f25e5f90c8d6f5951cd1cdce617]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/container:Container::container-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]
      ~ image: "sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0" => output<string>
    --docker:index/remoteImage:RemoteImage: (delete-replaced)
        [id=sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0ghcr.io/tylerhillery/pypacktrends/backend:latest]
        [urn=urn:pulumi:prod::pypacktrends::docker:index/remoteImage:RemoteImage::docker-image-backend]
        [provider=urn:pulumi:prod::pypacktrends::pulumi:providers:docker::default_4_5_7::cf7d9c84-d1ef-491b-80b8-4657f6ca20e9]

Do you want to perform this update? yes
Updating (prod)

View in Browser (Ctrl+O): https://app.pulumi.com/TylerHillery/pypacktrends/prod/updates/67

     Type                         Name                  Status               Info
     pulumi:pulumi:Stack          pypacktrends-prod
 +-  └─ docker:index:RemoteImage  docker-image-backend  replaced (0.12s)     [diff: ~pullTriggers]

Outputs:
    app:url                              : "https://pypacktrends.com"
    docker-container-backend:name        : "backend"
    docker-container-caddy:name          : "caddy"
    docker-image-backend:image-identifier: "sha256:ce47f74323e8e58486ea2b3d28f28cc2d205903aa148ce0483e2c7142fdb9df0"
    docker-image-caddy:image-identifier  : "sha256:f4a46102dd6c12c4066c3ece1efa6f1e456dcc2ad40564986f96b55a2b30f628"
    docker-network-caddy:name            : "caddy"
    docker-volume-caddy-config:name      : "caddy-config"
    docker-volume-caddy-data:name        : "caddy-data"
  ~ registry-image-backend:sha256-digest : "sha256:5fb359f8c60eab25e500f060926420923ba854d7c57f0dcaa4915cb700ea15cb" => "sha256:f78a14ca8b23c3e3a8230a95c2b72fadc398635917e923059d1b5e3137c82e6b"
    registry-image-caddy:sha256-digest   : "sha256:180fa44c9b368990554a274b7d999d61923cfb98cccc45b6c92826de232e7689"

Resources:
    +-1 replaced
    9 unchanged

Duration: 5s

root@pypacktrends-prod:/opt/pypacktrends/infra# docker images --digests
REPOSITORY                                  TAG       DIGEST                                                                    IMAGE ID       CREATED        SIZE
ghcr.io/tylerhillery/pypacktrends/backend   latest    sha256:3ff35d3756971450d68b41dd6f9a2c00ba06770b3359c4a4a7f5afbef0214309   ce47f74323e8   23 hours ago   1.19GB
ghcr.io/tylerhillery/pypacktrends/caddy     latest    sha256:180fa44c9b368990554a274b7d999d61923cfb98cccc45b6c92826de232e7689   f4a46102dd6c   5 days ago     49.2MB
root@pypacktrends-prod:/opt/pypacktrends/infra# docker ps
CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS                  PORTS                                                         NAMES
78beacd7533e   ce47f74323e8   "fastapi run --worke…"   22 hours ago   Up 22 hours (healthy)   0.0.0.0:8000->8000/tcp                                        backend
360bc9dd340e   f4a46102dd6c   "caddy run --config …"   23 hours ago   Up 23 hours             0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 443/udp, 2019/tcp   caddy
root@pypacktrends-prod:/opt/pypacktrends/infra# uv run pulumi refresh --stack prod
```


