### PR TITLE
fix: make update serivce script executable

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ def root() -> HTMLResponse:
             <title>PyPack Trends</title>
         </head>
         <body>
-            <h3>PyPack Trends 🐍 coming soon!</h3>
+            <h3>PyPack Trends 🐍 coming soon...</h3>
         </body>
     </html>
     """

--- a/infra/templates/cloud-init.yml
+++ b/infra/templates/cloud-init.yml
@@ -35,11 +35,11 @@ runcmd:
   - curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv_install.sh # curl: (23) Failed writing body (1311 != 1378)
   - HOME="/root" UV_UNMANAGED_INSTALL="/usr/local/bin" sh /tmp/uv_install.sh # https://github.com/astral-sh/uv/issues/6965
 
+  # make logs dir
+  - sudo -u {{ vps_username }} mkdir /home/{{ vps_username }}/logs
+
   # clone the repository
   - su - {{ vps_username }} -c "git clone https://github.com/{{ github_username }}/{{ project_name }}.git {{ vps_project_path }}"
-
-  # Make the update script executable
-  - chmod +x {{ vps_project_path }}/scripts/update_service.sh
 
   # start containers using full path to docker-compose.yml
   - docker compose -f {{ vps_project_path }}/docker-compose.yml up -d

--- a/scripts/update_service.sh
+++ b/scripts/update_service.sh
@@ -11,7 +11,7 @@ fi
 CONTAINER_REGISTRY_PREFIX=$1
 SERVICE_NAME=$2
 FULL_IMAGE_NAME="${CONTAINER_REGISTRY_PREFIX}/${SERVICE_NAME}:latest"
-LOG_FILE="/var/log/update_service_${SERVICE_NAME}.log"
+LOG_FILE="/home/github/logs/update_service_${SERVICE_NAME}.log"
 
 # Logging function
 log() {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Originally I was making the script executable in the cloud init process. I found out modifying the file privileges produces a git change which was causing issues with remote command when it tried to run the git pull.

I have the script executable locally and removed that step in the cloud init script. 

I was also having issues with github user accessing /var/log/ dir. I thought adding the user to admin group gave them access to this dir. I have changed the logs directory to /home/github/logs and updated the cloud init script to create this dir.
