### PR TITLE
fix: update service script

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ def root() -> HTMLResponse:
             <title>PyPack Trends</title>
         </head>
         <body>
-            <h3>PyPack Trends 🐍 coming soon...</h3>
+            <h3>PyPack Trends 🐍 coming soon!!!</h3>
         </body>
     </html>
     """

--- a/scripts/update_service.sh
+++ b/scripts/update_service.sh
@@ -73,7 +73,7 @@ fi
 # Update Caddy with the new container name
 log "Updating Caddy with the new container name for service $SERVICE_NAME..."
 CONTAINER_NAME=$(echo "${SERVICE_NAME}" | tr '[:lower:]' '[:upper:]')_CONTAINER_NAME
-docker exec -it "$caddy_container" /bin/sh -c "export ${CONTAINER_NAME}=$new_container && caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile"
+docker exec "$caddy_container" /bin/sh -c "export ${CONTAINER_NAME}=$new_container && caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile"
 
 # Remove the old container using the dangling image
 log "Removing old container: $old_container..."


### PR DESCRIPTION
## What kind of change does this PR introduce?
The update service script was failing during this part
```
log "Updating Caddy with the new container name for service $SERVICE_NAME..."
CONTAINER_NAME=$(echo "${SERVICE_NAME}" | tr '[:lower:]' '[:upper:]')_CONTAINER_NAME
docker exec -it "$caddy_container" /bin/sh -c "export ${CONTAINER_NAME}=$new_container && caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile"
```

Getting error 
```
 +  command:remote:Command remote-command creating (6s) the input device is not a TTY
```

This fails because the docker `-it` flag expects an interactive terminal TTY but this process doesn't have one.

### Additional Context
I keep changing the main.py file so I can trigger an update on the image and see the website change