### PR TITLE
feat: configure OIDC between Pulumi and GCP

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -10,6 +10,8 @@
 
 There shouldn't be too many pulumi commands that will need to be ran locally with the CI/CD pipeline that is in place but here are a few that could still be helpful:
 
-`pulumi preview` to see what impacts you might have on resources
-`pulumi stack output droplet:ipv4` to get pulumi stack outputs
-`esc env open pypacktrends/prod` to show decrypted secrets
+- `pulumi preview` to see what impacts you might have on resources
+- `pulumi stack output droplet:ipv4` to get pulumi stack outputs
+- `esc env open pypacktrends/prod` to show decrypted secrets
+- `pulumi.log.info()`
+- `pulumi env set pypacktrends/prod --plaintext --secret pulumiConfig.namespace:name-name value`

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,9 +3,10 @@ import pulumi_command as command
 import pulumi_cloudflare as cloudflare
 import pulumi_digitalocean as digitalocean
 import pulumi_docker_build as docker_build
+import pulumi_gcp as gcp
 import pulumi_tls as tls
 from config import settings
-from utils import get_cloud_init_script
+from utils import render_template
 
 backend_image = docker_build.Image(
     f"docker-build-image-{settings.BACKEND_SERVICE_NAME}",
@@ -30,17 +31,6 @@ pulumi.export(
     backend_image.ref,
 )
 
-user_data = get_cloud_init_script(
-    container_registry_address=settings.CONTAINER_REGISTRY_ADDRESS,
-    github_token=settings.GITHUB_TOKEN,
-    github_username=settings.GITHUB_USERNAME,
-    project_name=settings.PROJECT_NAME,
-    pulumi_access_token=settings.PULUMI_ACCESS_TOKEN,
-    tailscale_auth_key=settings.TAILSCALE_AUTH_KEY,
-    vps_username=settings.VPS_USERNAME,
-    vps_project_path=settings.VPS_PROJECT_PATH,
-)
-
 ssh_key = tls.PrivateKey("tls-private-key", algorithm="RSA", rsa_bits=4096)
 pulumi.export("ssh-key:private-key-pem", ssh_key.private_key_pem)
 
@@ -50,6 +40,19 @@ do_ssh_key = digitalocean.SshKey(
     public_key=ssh_key.public_key_openssh,
 )
 
+user_data = render_template(
+    template_name="cloud-init.yml",
+    container_registry_address=settings.CONTAINER_REGISTRY_ADDRESS,
+    github_token=settings.GITHUB_TOKEN,
+    github_username=settings.GITHUB_USERNAME,
+    project_name=settings.PROJECT_NAME,
+    pulumi_access_token=settings.PULUMI_ACCESS_TOKEN,
+    tailscale_auth_key=settings.TAILSCALE_AUTH_KEY,
+    vps_username=settings.VPS_USERNAME,
+    vps_project_path=settings.VPS_PROJECT_PATH,
+)
+pulumi.export("droplet:user-data", user_data)
+
 droplet = digitalocean.Droplet(
     "digitalocean-droplet",
     image="ubuntu-20-04-x64",
@@ -57,14 +60,7 @@ droplet = digitalocean.Droplet(
     region=digitalocean.Region.SFO3,
     size=digitalocean.DropletSlug.DROPLET_S1_VCPU1_GB,
     ssh_keys=[do_ssh_key.id],
-    user_data=get_cloud_init_script(
-        github_token=settings.GITHUB_TOKEN,
-        github_username=settings.GITHUB_USERNAME,
-        project_name=settings.PROJECT_NAME,
-        pulumi_access_token=settings.PULUMI_ACCESS_TOKEN,
-        tailscale_auth_key=settings.TAILSCALE_AUTH_KEY,
-        vps_username=settings.VPS_USERNAME,
-    ),
+    user_data=user_data,
     opts=pulumi.ResourceOptions(
         ignore_changes=["user_data"],
     ),
@@ -113,5 +109,56 @@ remote_command = command.remote.Command(
     """,
     triggers=[backend_image.ref],
 )
-pulumi.export("remote-command:stdout", remote_command.stdout)
-pulumi.export("remote-command:stderr", remote_command.stderr)
+
+gcp_project_config = gcp.organizations.get_project()
+gcp_project_id = gcp_project_config.number
+
+gcp_iam_workload_identity_pool_pulumi = gcp.iam.WorkloadIdentityPool(
+    "gcp-iam-workload-identity-pool-pulumi",
+    workload_identity_pool_id="pulumi-oidc",
+    display_name="Pulumi OIDC",
+)
+
+gcp_iam_workload_identity_pool_provider_pulumi = gcp.iam.WorkloadIdentityPoolProvider(
+    "gcp-iam-workload-identity-pool-provider-pulumi",
+    workload_identity_pool_id=gcp_iam_workload_identity_pool_pulumi.workload_identity_pool_id,
+    workload_identity_pool_provider_id="pulumi-oidc",
+    attribute_mapping={
+        "google.subject": "assertion.sub",
+    },
+    oidc=gcp.iam.WorkloadIdentityPoolProviderOidcArgs(
+        issuer_uri=settings.PULUMI_OIDC_ISSUER,
+        allowed_audiences=[f"gcp:{settings.ORG_NAME}"],
+    ),
+)
+
+gcp_service_account_pulumi = gcp.serviceaccount.Account(
+    "gcp-service-account-pulumi", account_id="pulumi-oidc", display_name="Pulumi OIDC"
+)
+
+gcp_project_iam_member_role_editor = gcp.projects.IAMMember(
+    "gcp-projects-iammember-editor-role",
+    member=gcp_service_account_pulumi.email.apply(
+        lambda email: f"serviceAccount:{email}"
+    ),
+    role="roles/editor",
+    project=gcp_project_id,
+)
+
+gcp_service_account_iam_binding_pulumi = gcp.serviceaccount.IAMBinding(
+    "gcp-service-account-iam-policy-binding-pulumi",
+    service_account_id=gcp_service_account_pulumi.name,
+    role="roles/iam.workloadIdentityUser",
+    members=gcp_iam_workload_identity_pool_pulumi.name.apply(
+        lambda name: [f"principalSet://iam.googleapis.com/{name}/*"]
+    ),
+)
+gcp_pulumi_esc_yml = render_template(
+    template_name="pulumi_esc_gcp.yml",
+    gcp_project=int(gcp_project_id),
+    workload_pool_id=gcp_iam_workload_identity_pool_provider_pulumi.workload_identity_pool_id,
+    provider_id=gcp_iam_workload_identity_pool_provider_pulumi.workload_identity_pool_provider_id,
+    service_account_email=gcp_service_account_pulumi.email,
+)
+
+pulumi.export("pulumi:esc-yml-gcp", gcp_pulumi_esc_yml)

--- a/infra/config.py
+++ b/infra/config.py
@@ -4,6 +4,7 @@ import pulumi
 class Settings:
     STACK_NAME: str = pulumi.get_stack()
     PROJECT_NAME: str = pulumi.get_project()
+    ORG_NAME: str = pulumi.get_organization()
 
     backend_service_config: pulumi.Config = pulumi.Config("backend-service")
     BACKEND_SERVICE_PATH: str = backend_service_config.get("path") or "../backend"
@@ -48,6 +49,9 @@ class Settings:
 
     pulumi_config: pulumi.Config = pulumi.Config("pulumi")
     PULUMI_ACCESS_TOKEN: pulumi.Output | None = pulumi_config.get_secret("token")
+    PULUMI_OIDC_ISSUER: str = (
+        pulumi_config.get("oidc-issuer") or "https://api.pulumi.com/oidc"
+    )
 
     tailscale_config: pulumi.Config = pulumi.Config("tailscale")
     TAILSCALE_AUTH_KEY: pulumi.Output | None = tailscale_config.get_secret("auth-key")
@@ -56,16 +60,16 @@ class Settings:
     VPS_USERNAME: str = vps_config.get("username") or "github"
 
     @property
+    def BACKEND_DOCKER_IMAGE_URL(self) -> str:
+        return f"{self.CONTAINER_REGISTRY_PREFIX}/{self.BACKEND_SERVICE_NAME}"
+
+    @property
     def CONTAINER_REGISTRY_PREFIX(self) -> str:
         return (
             f"{self.CONTAINER_REGISTRY_ADDRESS}/"
             f"{self.GITHUB_USERNAME}/"
             f"{self.CONTAINER_REGISTRY_REPOSITORY}"
         )
-
-    @property
-    def BACKEND_DOCKER_IMAGE_URL(self) -> str:
-        return f"{self.CONTAINER_REGISTRY_PREFIX}/{self.BACKEND_SERVICE_NAME}"
 
     @property
     def VPS_PROJECT_PATH(self) -> str:

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pulumi-digitalocean>=4.34.0",
     "pulumi-docker-build>=0.0.7",
     "pulumi-docker>=4.5.7",
+    "pulumi-gcp>=8.8.1",
     "pulumi-github>=6.3.2",
     "pulumi-tls>=5.0.9",
     "pulumi>=3.137.0",

--- a/infra/templates/cloud-init.yml
+++ b/infra/templates/cloud-init.yml
@@ -39,10 +39,10 @@ runcmd:
   - sudo -u {{ vps_username }} mkdir /home/{{ vps_username }}/logs
 
   # clone the repository
-  - su - {{ vps_username }} -c "git clone https://github.com/{{ github_username }}/{{ project_name }}.git {{ vps_project_path }}"
+  - sudo -u {{ vps_username }} git clone https://github.com/{{ github_username }}/{{ project_name }}.git {{ vps_project_path }}
 
   # start containers using full path to docker-compose.yml
-  - docker compose -f {{ vps_project_path }}/docker-compose.yml up -d
+  - sudo -u {{ vps_username }} docker compose -f {{ vps_project_path }}/docker-compose.yml up -d
 
   # ufw configs
   - ufw allow OpenSSH

--- a/infra/templates/pulumi_esc_gcp.yml
+++ b/infra/templates/pulumi_esc_gcp.yml
@@ -1,0 +1,12 @@
+values:
+  gcp:
+    login:
+      fn::open::gcp-login:
+        project: "{{ gcp_project }}"
+        oidc:
+          workloadPoolId: "{{ workload_pool_id }}"
+          providerId: "{{ provider_id }}"
+          serviceAccount: "{{ service_account_email }}"
+  environmentVariables:
+    GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
+    GOOGLE_PROJECT: ${gcp.login.project}

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -4,10 +4,10 @@ import pulumi
 from jinja2 import Environment, FileSystemLoader
 
 
-def get_cloud_init_script(**kwargs: str | pulumi.Output | None) -> Any:
-    def render_cloud_init_template(kwargs: dict[str, str]) -> Any:
+def render_template(template_name: str, **kwargs: str | pulumi.Output | None) -> Any:
+    def _render_template(kwargs: dict[str, str]) -> Any:
         env = Environment(loader=FileSystemLoader("./templates"))
-        template = env.get_template("cloud-init.yml")
+        template = env.get_template(template_name)
         return template.render(**kwargs)
 
-    return pulumi.Output.all(**kwargs).apply(render_cloud_init_template)
+    return pulumi.Output.all(**kwargs).apply(_render_template)

--- a/infra/uv.lock
+++ b/infra/uv.lock
@@ -85,6 +85,7 @@ dependencies = [
     { name = "pulumi-digitalocean" },
     { name = "pulumi-docker" },
     { name = "pulumi-docker-build" },
+    { name = "pulumi-gcp" },
     { name = "pulumi-github" },
     { name = "pulumi-tls" },
 ]
@@ -100,6 +101,7 @@ requires-dist = [
     { name = "pulumi-digitalocean", specifier = ">=4.34.0" },
     { name = "pulumi-docker", specifier = ">=4.5.7" },
     { name = "pulumi-docker-build", specifier = ">=0.0.7" },
+    { name = "pulumi-gcp", specifier = ">=8.8.1" },
     { name = "pulumi-github", specifier = ">=6.3.2" },
     { name = "pulumi-tls", specifier = ">=5.0.9" },
 ]
@@ -289,6 +291,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/31/76/b028b3958772b8f9c014421c9e97a5ecdcac9a1064b1b4e5b6c5395f091b/pulumi_docker_build-0.0.7.tar.gz", hash = "sha256:712afb5eec328ccb9af0827e10a5d70f829ede25a558a1a7fe8d4099c6c64cfb", size = 38899 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/68/f028a3123fdec371e4c09e88b0350f4f1758e4b1d756ba263aa5e5277839/pulumi_docker_build-0.0.7-py3-none-any.whl", hash = "sha256:4af7f94a586a37e04d1fc01dc1a1e424b2535a0ec962101180c87596dd5ff947", size = 43492 },
+]
+
+[[package]]
+name = "pulumi-gcp"
+version = "8.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parver" },
+    { name = "pulumi" },
+    { name = "semver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fb/f06f860aea4440ac7c9190ee53e2756d7968f315477d32e8d60601951e08/pulumi_gcp-8.8.1.tar.gz", hash = "sha256:6e4e4f085deb5d866ad66bdd87f733c2518ec088d7e2e5fc74936fc349e7e32c", size = 6436651 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/67/995cbfe50900e421ff80e40a34e33ed734f7ccfa68ff6978416576325e03/pulumi_gcp-8.8.1-py3-none-any.whl", hash = "sha256:2e6bd90f32be5c611d3283e5d1a8ed8600b774aa8e0ab29abf7beb0ca34a1687", size = 8237549 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What kind of change does this PR introduce?
This change introduces OIDC between pulumi and gcp. GCP is going to be needed in the future so we can create a GCP client to query the PyPI downloads public data set.

I followed these resources and added the outputted yml into my esc.
- [Google Cloud (GCP) Classic: Installation & Configuration](https://www.pulumi.com/registry/packages/gcp/installation-configuration/)
- [Provisioning an OIDC Provider in Google Cloud for Pulumi Cloud](https://github.com/pulumi/examples/tree/master/gcp-py-oidc-provider-pulumi-cloud)
- [Configuring OpenID Connect for Google Cloud](https://www.pulumi.com/docs/pulumi-cloud/access-management/oidc/provider/gcp/)

To reuse the cloud init render template function I refactored the function to pass in the template name you want to render. While doing this I finally figured out why #32 was failing and this was because I was redefining the user-data when I was passing it into the droplet resource args 🤦‍♂️

### Additional Context
Other minor changes
- reorder configs to be alphabetical
- updated docs with helpful pulumi commands
- export user data now incase I need to debug in the future

Fixes #32 