### PR TITLE
feat: pulumify github actions secrets

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,6 +3,7 @@ import pulumi_command as command
 import pulumi_cloudflare as cloudflare
 import pulumi_digitalocean as digitalocean
 import pulumi_docker_build as docker_build
+import pulumi_github as github
 import pulumi_gcp as gcp
 import pulumi_tls as tls
 from config import settings
@@ -108,6 +109,34 @@ remote_command = command.remote.Command(
         ./scripts/update_service.sh {settings.CONTAINER_REGISTRY_PREFIX} {settings.BACKEND_SERVICE_NAME}
     """,
     triggers=[backend_image.ref],
+)
+
+github_actions_secret_pulumi_token = github.ActionsSecret(
+    "github-actions-secret-github-token",
+    secret_name="GH_TOKEN",
+    repository=settings.GITHUB_REPOSITORY,
+    plaintext_value=settings.GITHUB_TOKEN,
+)
+
+github_actions_secret_pulumi_token = github.ActionsSecret(
+    "github-actions-secret-pulumi-token",
+    secret_name="PULUMI_ACCESS_TOKEN",
+    repository=settings.GITHUB_REPOSITORY,
+    plaintext_value=settings.PULUMI_ACCESS_TOKEN,
+)
+
+github_actions_secret_tailscale_oauth_client_id = github.ActionsSecret(
+    "github-actions-secret-tailscale-oauth-client-id",
+    secret_name="TS_OAUTH_CLIENT_ID",
+    repository=settings.GITHUB_REPOSITORY,
+    plaintext_value=settings.TAILSCALE_OAUTH_CLIENT_ID,
+)
+
+github_actions_secret_tailscale_oauth_client_secret = github.ActionsSecret(
+    "github-actions-secret-tailscale-oauth-client-secret",
+    secret_name="TS_OAUTH_SECRET",
+    repository=settings.GITHUB_REPOSITORY,
+    plaintext_value=settings.TAILSCALE_OAUTH_CLIENT_SECRET,
 )
 
 gcp_project_config = gcp.organizations.get_project()

--- a/infra/config.py
+++ b/infra/config.py
@@ -55,6 +55,12 @@ class Settings:
 
     tailscale_config: pulumi.Config = pulumi.Config("tailscale")
     TAILSCALE_AUTH_KEY: pulumi.Output | None = tailscale_config.get_secret("auth-key")
+    TAILSCALE_OAUTH_CLIENT_ID: pulumi.Output | None = tailscale_config.get_secret(
+        "oauth-client-id"
+    )
+    TAILSCALE_OAUTH_CLIENT_SECRET: pulumi.Output | None = tailscale_config.get_secret(
+        "oauth-client-secret"
+    )
 
     vps_config: pulumi.Config = pulumi.Config("vps")
     VPS_USERNAME: str = vps_config.get("username") or "github"
@@ -70,6 +76,10 @@ class Settings:
             f"{self.GITHUB_USERNAME}/"
             f"{self.CONTAINER_REGISTRY_REPOSITORY}"
         )
+
+    @property
+    def GITHUB_REPOSITORY(self) -> str:
+        return f"https://github.com/{settings.GITHUB_USERNAME}/{self.PROJECT_NAME}"
 
     @property
     def VPS_PROJECT_PATH(self) -> str:


### PR DESCRIPTION
## What kind of change does this PR introduce?
Resolves #18 to add github action secrets to pulumi. This makes it so all secrets are managed in Pulumi and I never have to worry about updating two different spots.

### Additional Context
I do have to be careful and make sure to update the token before it expires in the future as the current token will be required to "roll itself"