### PR TITLE
fix: github repo config name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Pulumi Up Prod
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Pulumi Preview Prod
 
 on:
   pull_request:

--- a/infra/config.py
+++ b/infra/config.py
@@ -79,7 +79,7 @@ class Settings:
 
     @property
     def GITHUB_REPOSITORY(self) -> str:
-        return f"https://github.com/{settings.GITHUB_USERNAME}/{self.PROJECT_NAME}"
+        return f"{settings.GITHUB_USERNAME}/{self.PROJECT_NAME}"
 
     @property
     def VPS_PROJECT_PATH(self) -> str:


### PR DESCRIPTION
## What kind of change does this PR introduce?
I messed up the `GITHUB_REPOSITORY` value for the github actions secrets, I just need the name username and project name

### Additional Context
Related PR #37 