### PR TITLE
fix: pypi package filter prod target

### DIFF
--- a/dbt/macros/pypi_package_filter.sql
+++ b/dbt/macros/pypi_package_filter.sql
@@ -13,6 +13,8 @@
 
     {%- if target.name != 'prod' -%}
         {{ column_name }} in ('{{ package_list | join("', '") }}')
+    {%- else -%}
+        true
     {%- endif -%}
 
 {% endmacro %}

--- a/dbt/models/staging/bq_public_data_pypi/stg_bq_public_data_pypi__file_downloads.sql
+++ b/dbt/models/staging/bq_public_data_pypi/stg_bq_public_data_pypi__file_downloads.sql
@@ -15,8 +15,7 @@ renamed as (
         tls_cipher   as package_download_tls_cipher
     from
         source
-    where
-        {{ pypi_package_filter('project') }}
+    where {{ pypi_package_filter('project') }}
 )
 
 select * from renamed


### PR DESCRIPTION
## What kind of change does this PR introduce?
The prod dbt target for the pypi package filter returns nothing so it was causing sql error, added it default to "true"

### Additional Context
