### PR TITLE
chore: reduce fastapi workers to 2

### DIFF
--- a/backend/scripts/start_backend.sh
+++ b/backend/scripts/start_backend.sh
@@ -15,5 +15,5 @@ cd "$PROJECT_ROOT"
 if [ "${ENVIRONMENT}" = "dev" ]; then
     exec fastapi run --reload app/main.py
 else
-    exec fastapi run --workers 4 app/main.py
+    exec fastapi run --workers 2 app/main.py
 fi


### PR DESCRIPTION
## What kind of change does this PR introduce?
My droplet was running a high memory usage, I don't think it can handle 4 fastapi workers, going to try 2

### Additional Context
