### PR TITLE
chore: remove strict from sqlite schema

### DIFF
--- a/backend/app/alembic/versions/eb3ad385519a_init_database_upgrade.sql
+++ b/backend/app/alembic/versions/eb3ad385519a_init_database_upgrade.sql
@@ -9,7 +9,7 @@ create table pypi_package_downloads_weekly_metrics (
     weeks_since_first_distribution integer not null,
     synced_at                      text    not null,
     primary key (package_name, package_downloaded_week)
-) strict;
+);
 
 create index idx_package_name
 on pypi_package_downloads_weekly_metrics (package_name);
@@ -25,7 +25,7 @@ create table pypi_packages (
     package_download_url   text,
     package_uploaded_at    text not null,
     synced_at              text not null
-) strict;
+);
 
 create index idx_package_uploaded_at
 on pypi_packages (package_uploaded_at);

--- a/backend/app/tests/alembic/test_utils.py
+++ b/backend/app/tests/alembic/test_utils.py
@@ -59,7 +59,7 @@ def test_read_sql_file(alembic_sql_upgrade_file: Path) -> None:
                 weeks_since_first_distribution  integer not null,
                 synced_at                       text    not null,
                 primary key (package_name, package_downloaded_week)
-            ) strict
+            )
             """,
             """create index idx_package_name
                on pypi_package_downloads_weekly_metrics (package_name)
@@ -75,7 +75,7 @@ def test_read_sql_file(alembic_sql_upgrade_file: Path) -> None:
                 package_download_url    text,
                 package_uploaded_at     text not null,
                 synced_at               text not null
-            ) strict
+            )
             """,
             """create index idx_package_uploaded_at
                on pypi_packages (package_uploaded_at)

--- a/infra/templates/cloud-init.yml
+++ b/infra/templates/cloud-init.yml
@@ -22,6 +22,7 @@ runcmd:
   # system updates
   - apt update
   - DEBIAN_FRONTEND=noninteractive apt upgrade -y --allow-downgrades --allow-remove-essential --allow-change-held-packages
+  - apt install -y sqlite3
 
   # docker configs
   - curl -fssl https://get.docker.com | sh


### PR DESCRIPTION
## What kind of change does this PR introduce?
I couldn't figure out how to get newer SQLite3 version on my droplet and the current version doesn't support `strict` so I am going to drop it for now.

Also updated cloud init to install sqlite3 

### Additional Context
