### PR TITLE
fix: sentry dsn

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -60,6 +60,9 @@ jobs:
         run: dbt deps
       - name: SQLFluff
         run: ./scripts/sqlfluff.sh
+      - name: Create CI BQ dataset
+        run: |
+          bq mk --location=US dbt_pr_${{ github.event.pull_request.number }} || true
       - name: Clone dbt incremental models
         run: dbt clone --target ci --select state:modified+,config.materialized:incremental,state:old --state ./prod-run-artifacts
       - name: dbt Build

--- a/infra/config.py
+++ b/infra/config.py
@@ -61,7 +61,7 @@ class Settings:
     )
 
     sentry_config: pulumi.Config = pulumi.Config("sentry")
-    SENTRY_DSN: pulumi.Output | None = pulumi_config.get_secret("dsn")
+    SENTRY_DSN: pulumi.Output | None = sentry_config.get_secret("dsn")
 
     tailscale_config: pulumi.Config = pulumi.Config("tailscale")
     TAILSCALE_AUTH_KEY: pulumi.Output | None = tailscale_config.get_secret("auth-key")

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -11,3 +11,14 @@ def render_template(template_name: str, **kwargs: str | pulumi.Output | None) ->
         return template.render(**kwargs)
 
     return pulumi.Output.all(**kwargs).apply(_render_template)
+
+
+def create_cmd(**kwargs: str | pulumi.Output | None) -> Any:
+    def _create_cmd(kwargs: dict[str, str]) -> Any:
+        return f"""
+        cd {kwargs["vps_project_path"]}
+        git pull
+        SENTRY_DSN='{kwargs["sentry_dsn"]}' ./scripts/update_service.sh {kwargs["container_registry_prefix"]} {kwargs["backend_service_name"]}
+    """
+
+    return pulumi.Output.all(**kwargs).apply(_create_cmd)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Had a bug with passing in "None" as the sentry dsn, this was caused by copy paste error when creating the `sentry_config` and retrieving the dsn I didn't update the `pulumi_config` to use the `sentry_config`. This is fixed now and I changed the way the remote command create is created so I can export and debug easier.

### Additional Context
resolves #68 
