### PR TITLE
fix: sentry gha release

### DIFF
--- a/.github/workflows/pulumi-up-prod.yml
+++ b/.github/workflows/pulumi-up-prod.yml
@@ -47,7 +47,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Create Sentry release
-        if: steps.pulumi.outputs['docker-build-image-backend:ref'] != steps.pulumi.outputs['docker-build-image-backend:old-ref']
+        if: steps.pulumi.outputs.docker_build_image_backend_ref != steps.pulumi.outputs.docker_build_image_backend_old_ref
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Sentry GHA release was not triggering even when the new backend image ref changed

### Additional Context
