### PR TITLE
fix: log level package validation

### DIFF
--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -53,7 +53,7 @@ async def create_package(
         )
 
     if not validate_package(package_name):
-        logger.error(f"Invalid package name: {package_name} - not found on PyPI")
+        logger.warning(f"Invalid package name: {package_name} - not found on PyPI")
         return HTMLResponse(
             status_code=422, content=f"'{package_name}' not found on PyPI"
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Sentry was triggering alerts on post requests to package-list for invalid python packages. I incorrectly configured the log level to `error` when my server properly validated the package as incorrect and returned a 422. I changed log level to warn.

### Additional Context
