### PR TITLE
fix: when sync has no rows

### DIFF
--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -60,6 +60,11 @@ def sync_pypi_packages(
         page_size=BATCH_SIZE
     )
     total_rows = rows.total_rows
+
+    if total_rows < 1:
+        logger.info("No rows to insert")
+        return
+
     logger.info(f"Total rows to insert: {total_rows}")
 
     upsert_sql = text("""
@@ -79,6 +84,7 @@ def sync_pypi_packages(
             start_batch_time = time.time()
 
             packages = [dict(row.items()) for row in page]
+            print(packages)
             row_count += len(packages)
 
             logger.info(f"Inserting {row_count} of {total_rows} rows...")
@@ -136,6 +142,11 @@ def sync_pypi_downloads(
         page_size=BATCH_SIZE
     )
     total_rows = rows.total_rows
+
+    if total_rows < 1:
+        logger.info("No rows to insert")
+        return
+
     logger.info(f"Total rows to insert: {total_rows}")
 
     delete_sql = text("""

--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -84,7 +84,7 @@ def sync_pypi_packages(
             start_batch_time = time.time()
 
             packages = [dict(row.items()) for row in page]
-            print(packages)
+
             row_count += len(packages)
 
             logger.info(f"Inserting {row_count} of {total_rows} rows...")


### PR DESCRIPTION
## What kind of change does this PR introduce?
when sync has no rows to insert it was still trying to execute the insert queries. Prior assumption was the for loop would have never entered the block if there are no rows to insert but that assumption was wrong now that we use the row.pages vs islice iter(rows)

### Additional Context
