### PR TITLE
fix: github action sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -85,5 +85,5 @@ jobs:
           ssh -o StrictHostKeyChecking=no github@pypacktrends-prod '
             cd /home/github/pypacktrends && \
             git pull && \
-            ./scripts/sync.sh "$START_WEEK" "$END_WEEK"
+            ./scripts/sync.sh \"$START_WEEK\" \"$END_WEEK\"
           '

--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -237,6 +237,9 @@ def main() -> None:
             sync_pypi_packages(read_engine, write_engine)
         case "downloads":
             sync_pypi_downloads(write_engine, *parse_dates(sys.argv))
+        case "all":
+            sync_pypi_packages(read_engine, write_engine)
+            sync_pypi_downloads(write_engine, *parse_dates(sys.argv))
         case _:
             logger.error("Unknown entity. Please use 'packages' or 'downloads'")
             sys.exit(1)

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -18,12 +18,8 @@ fi
 echo "Using container: $backend_container"
 
 docker cp ${REMOTE_CREDS_PATH} $backend_container:${REMOTE_CREDS_PATH}
-docker exec \
-    -e GOOGLE_APPLICATION_CREDENTIALS=${REMOTE_CREDS_PATH} \
-    -e GOOGLE_CLOUD_PROJECT=pypacktrends-prod \
-    $backend_container python /app/app/sync.py packages
 
 docker exec \
     -e GOOGLE_APPLICATION_CREDENTIALS=${REMOTE_CREDS_PATH} \
     -e GOOGLE_CLOUD_PROJECT=pypacktrends-prod \
-    $backend_container python /app/app/sync.py downloads ${START_WEEK} ${END_WEEK}
+    $backend_container python /app/app/sync.py all ${START_WEEK} ${END_WEEK}


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR introduces a new command line option for `sync.py` to sync both downloads and packages. I have also tried to fix the github action to properly passing the start week and end week args but escaping the quotes.

### Additional Context
