### PR TITLE
fix: weeks in range dbt macro

### DIFF
--- a/dbt/macros/get_date_range_bounds.sql
+++ b/dbt/macros/get_date_range_bounds.sql
@@ -1,7 +1,15 @@
 {% macro get_date_range_bounds() %}
     {% set run_started_week = run_started_at - modules.datetime.timedelta(days=run_started_at.weekday()) %}
     {% set one_week_ago = (run_started_week - modules.datetime.timedelta(weeks=1)).strftime("%Y-%m-%d") %}
+
     {% set start_date = var('start_date', one_week_ago) | string %}
     {% set end_date = var('end_date', one_week_ago) | string %}
-    {% do return(["'" ~ start_date ~ "'", "'" ~ end_date ~ "'"]) %}
+
+    {% set start_datetime = modules.datetime.datetime.strptime(start_date, "%Y-%m-%d") %}
+    {% set end_datetime = modules.datetime.datetime.strptime(end_date, "%Y-%m-%d") %}
+
+    {% set start_week = (start_datetime - modules.datetime.timedelta(days=start_datetime.weekday())).strftime("%Y-%m-%d") %}
+    {% set end_week = (end_datetime - modules.datetime.timedelta(days=end_datetime.weekday())).strftime("%Y-%m-%d") %}
+
+    {% do return(["'" ~ start_week ~ "'", "'" ~ end_week ~ "'"]) %}
 {% endmacro %}

--- a/dbt/macros/weeks_in_range.sql
+++ b/dbt/macros/weeks_in_range.sql
@@ -7,7 +7,7 @@
     {% set start_week = start_date - modules.datetime.timedelta(days=start_date.weekday()) %}
     {% set end_week = end_date - modules.datetime.timedelta(days=end_date.weekday()) %}
 
-    {% set day_count = (start_week - end_week).days %}
+    {% set day_count = (end_week - start_week).days %}
     {% set week_count = day_count // 7 %}
 
     {% if week_count < 0 %}

--- a/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
+++ b/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
@@ -3,7 +3,7 @@
 {% set start_date = partitions_to_replace[0] %}
 {% set end_date = partitions_to_replace[1] %}
 
-{% set partitions_to_replace = dates_in_range(
+{% set partitions_to_replace = weeks_in_range(
     start_date_str=start_date,
     end_date_str=end_date,
     in_fmt="'%Y-%m-%d'",
@@ -36,7 +36,11 @@ weekly_downloads as (
     from
         {{ ref('stg_bq_public_data_pypi__file_downloads') }}
     where
-        date_trunc(package_downloaded_at, week (monday)) between {{ start_date }} and {{ end_date }}
+        date(package_downloaded_at) between date_trunc(
+            {{ start_date }}, week (monday)
+        ) and date_trunc(
+            {{ end_date }}, week (monday)
+        )
     group by
         1, 2
 )

--- a/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
+++ b/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
@@ -41,6 +41,7 @@ weekly_downloads as (
         ) and date_trunc(
             {{ end_date }}, week (monday)
         )
+        and {{ pypi_package_filter('package_name') }}
     group by
         1, 2
 )

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+if [ ! -f "$PROJECT_ROOT/.env" ]; then
+    echo "Error: .env file not found in project root"
+    exit 1
+fi
+
+mkdir -p "$PROJECT_ROOT/data"
+
+env $(cat "$PROJECT_ROOT/.env") litestream restore \
+    -config "$PROJECT_ROOT/litestream/litestream.yml" \
+    -o "$PROJECT_ROOT/data/pypacktrends.db" \
+    /data/pypacktrends.db
+
+if [ $? -eq 0 ]; then
+    echo "Database successfully restored to $PROJECT_ROOT/data/pypacktrends.db"
+else
+    echo "Error: Database restore failed"
+    exit 1
+fi


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR ensures that we dbt weekly downloads always operates on start of weeks dates so we don't accidentally enter in a date range mid week which would result in a partial week of data

### Additional Context
