### PR TITLE
fix: dbt date range and package lower

### DIFF
--- a/dbt/macros/get_date_range_bounds.sql
+++ b/dbt/macros/get_date_range_bounds.sql
@@ -1,15 +1,28 @@
 {% macro get_date_range_bounds() %}
     {% set run_started_week = run_started_at - modules.datetime.timedelta(days=run_started_at.weekday()) %}
+    {% set run_started_week_str =  run_started_week.strftime("%Y-%m-%d") %}
+
     {% set one_week_ago = (run_started_week - modules.datetime.timedelta(weeks=1)).strftime("%Y-%m-%d") %}
 
     {% set start_date = var('start_date', one_week_ago) | string %}
-    {% set end_date = var('end_date', one_week_ago) | string %}
+    {% set end_date = var('end_date', run_started_week_str) | string %}
 
     {% set start_datetime = modules.datetime.datetime.strptime(start_date, "%Y-%m-%d") %}
     {% set end_datetime = modules.datetime.datetime.strptime(end_date, "%Y-%m-%d") %}
 
-    {% set start_week = (start_datetime - modules.datetime.timedelta(days=start_datetime.weekday())).strftime("%Y-%m-%d") %}
-    {% set end_week = (end_datetime - modules.datetime.timedelta(days=end_datetime.weekday())).strftime("%Y-%m-%d") %}
+    {% set start_week = start_datetime - modules.datetime.timedelta(days=start_datetime.weekday()) %}
+    {% set end_week = end_datetime - modules.datetime.timedelta(days=end_datetime.weekday()) %}
 
-    {% do return(["'" ~ start_week ~ "'", "'" ~ end_week ~ "'"]) %}
+    {% if start_week >= end_week %}
+        {% do exceptions.raise_compiler_error("start_date week (" ~ start_week.strftime("%Y-%m-%d") ~ ") must be before end_date week (" ~ end_week.strftime("%Y-%m-%d") ~ ")") %}
+    {% endif %}
+
+    {% set start_week_str = start_week.strftime("%Y-%m-%d") %}
+    {% set end_week_str = end_week.strftime("%Y-%m-%d") %}
+
+    {% if end_week_str > run_started_week_str %}
+        {% do exceptions.raise_compiler_error("end_week cannot be greater than the start of the current week (" ~ run_started_week_str ~ ")") %}
+    {% endif %}
+
+    {% do return(["'" ~ start_week_str ~ "'", "'" ~ end_week_str ~ "'"]) %}
 {% endmacro %}

--- a/dbt/macros/weeks_in_range.sql
+++ b/dbt/macros/weeks_in_range.sql
@@ -19,7 +19,7 @@
     {% endif %}
 
     {% set date_list = [] %}
-    {% for i in range(0, week_count + 1) %}
+    {% for i in range(0, week_count) %}
         {% set the_date = (modules.datetime.timedelta(weeks=i) + start_week) %}
         {% if not out_fmt %}
             {% set _ = date_list.append(the_date) %}

--- a/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
+++ b/dbt/models/marts/pypi/pypi_package_downloads_per_week.sql
@@ -1,7 +1,7 @@
-{% set partitions_to_replace = get_date_range_bounds() %}
+{% set date_range = get_date_range_bounds() %}
 
-{% set start_date = partitions_to_replace[0] %}
-{% set end_date = partitions_to_replace[1] %}
+{% set start_date = date_range[0] %}
+{% set end_date = date_range[1] %}
 
 {% set partitions_to_replace = weeks_in_range(
     start_date_str=start_date,
@@ -35,12 +35,9 @@ weekly_downloads as (
         count(*)                                               as downloads
     from
         {{ ref('stg_bq_public_data_pypi__file_downloads') }}
-    where
-        date(package_downloaded_at) between date_trunc(
-            {{ start_date }}, week (monday)
-        ) and date_trunc(
-            {{ end_date }}, week (monday)
-        )
+    where true
+        and package_downloaded_at >= timestamp(date_trunc({{ start_date }}, week (monday)))
+        and package_downloaded_at < timestamp(date_trunc({{ end_date}}, week (monday)))
         and {{ pypi_package_filter('package_name') }}
     group by
         1, 2

--- a/dbt/models/staging/bq_public_data_pypi/stg_bq_public_data_pypi__distribution_metadata.sql
+++ b/dbt/models/staging/bq_public_data_pypi/stg_bq_public_data_pypi__distribution_metadata.sql
@@ -6,7 +6,7 @@ source as (
 renamed as (
     select
         metadata_version         as package_metadata_version,
-        name                     as package_name,
+        lower(name)              as package_name,
         version                  as package_version,
         summary                  as package_summary,
         description              as package_description,

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -9,7 +9,7 @@ pypacktrends:
       priority: batch
       threads: 4
       timeout_seconds: 300
-      maximum_bytes_billed: 300000000000
+      maximum_bytes_billed: 10000000000
 
     ci:
       type: bigquery
@@ -19,7 +19,7 @@ pypacktrends:
       priority: batch
       threads: 4
       timeout_seconds: 300
-      maximum_bytes_billed: 300000000000
+      maximum_bytes_billed: 10000000000
     prod:
       type: bigquery
       method: oauth

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -9,7 +9,7 @@ pypacktrends:
       priority: batch
       threads: 4
       timeout_seconds: 300
-      maximum_bytes_billed: 10000000000
+      maximum_bytes_billed: 300000000000
 
     ci:
       type: bigquery
@@ -19,7 +19,7 @@ pypacktrends:
       priority: batch
       threads: 4
       timeout_seconds: 300
-      maximum_bytes_billed: 10000000000
+      maximum_bytes_billed: 300000000000
     prod:
       type: bigquery
       method: oauth


### PR DESCRIPTION
## What kind of change does this PR introduce?
Two issues with the dbt models
1. The package name in pypi distribtuion metadata is case sensitive but the downloads data is always lower case
2. The package downloaded week filter was using `between` and on the most recent week meant it was only filtering for one day.

### Additional Context
