### PR TITLE
chore: remove lower from package search

### DIFF
--- a/backend/app/alembic/versions/eb3ad385519a_init_database_downgrade.sql
+++ b/backend/app/alembic/versions/eb3ad385519a_init_database_downgrade.sql
@@ -1,6 +1,2 @@
-drop index if exists idx_package_name;
-drop index if exists idx_package_downloaded_week;
 drop table if exists pypi_package_downloads_weekly_metrics;
-
-drop index if exists idx_package_uploaded_at;
 drop table if exists pypi_packages;

--- a/backend/app/alembic/versions/eb3ad385519a_init_database_upgrade.sql
+++ b/backend/app/alembic/versions/eb3ad385519a_init_database_upgrade.sql
@@ -11,12 +11,6 @@ create table pypi_package_downloads_weekly_metrics (
     primary key (package_name, package_downloaded_week)
 );
 
-create index idx_package_name
-on pypi_package_downloads_weekly_metrics (package_name);
-
-create index idx_package_downloaded_week
-on pypi_package_downloads_weekly_metrics (package_downloaded_week);
-
 create table pypi_packages (
     package_name           text not null primary key,
     latest_package_version text not null,
@@ -26,6 +20,3 @@ create table pypi_packages (
     package_uploaded_at    text not null,
     synced_at              text not null
 );
-
-create index idx_package_uploaded_at
-on pypi_packages (package_uploaded_at);

--- a/backend/app/tests/alembic/test_utils.py
+++ b/backend/app/tests/alembic/test_utils.py
@@ -60,12 +60,6 @@ def test_read_sql_file(alembic_sql_upgrade_file: Path) -> None:
                 primary key (package_name, package_downloaded_week)
             )
             """,
-            """create index idx_package_name
-               on pypi_package_downloads_weekly_metrics (package_name)
-            """,
-            """create index idx_package_downloaded_week
-               on pypi_package_downloads_weekly_metrics (package_downloaded_week)
-            """,
             """create table pypi_packages (
                 package_name            text not null primary key,
                 latest_package_version  text not null,
@@ -75,9 +69,6 @@ def test_read_sql_file(alembic_sql_upgrade_file: Path) -> None:
                 package_uploaded_at     text not null,
                 synced_at               text not null
             )
-            """,
-            """create index idx_package_uploaded_at
-               on pypi_packages (package_uploaded_at)
             """,
         )
     )

--- a/backend/app/views/routes/search.py
+++ b/backend/app/views/routes/search.py
@@ -57,9 +57,9 @@ def get_search_results(
             from
                 pypi_packages
             where
-                lower(package_name) like :package_name
+                package_name like :package_name
             order by
-                lower(package_name) limit 10
+                package_name limit 10
             """),
             {"package_name": package_name + "%"},
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?
In PR #101 I have changed the PyPI distribution data to lower all package names. The reasoning for this was due to downloads data being all  lowercase, so joining between the two datasets was dropping records. Because all packages are lower we don't need to runt he lower function on the search anymore.

I have also removed some indexes that were only used during the weekly sync. This improved the db file size from 17GB to 11.5GB. While query performance is now worse (by a few seconds), since these queries occur once a week I think it's a worth while tradeoff.

### Additional Context
