### PR TITLE
feat: weekly pipeline github action

### DIFF
--- a/.github/workflows/dbt-pypi.yml
+++ b/.github/workflows/dbt-pypi.yml
@@ -1,4 +1,4 @@
-name: Sync
+name: dbt PyPI
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  sync:
+  dbt-pypi:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -40,8 +40,8 @@ jobs:
           enable-cache: true
       - name: Install python dependencies
         run: |
-          export UV_PROJECT_ENVIRONMENT="${pythonLocation}"
-          uv sync --frozen
+            export UV_PROJECT_ENVIRONMENT="${pythonLocation}"
+            uv sync --frozen
       - name: Connect Tailscale
         uses: tailscale/github-action@v2
         with:
@@ -56,8 +56,10 @@ jobs:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.DBT_SERVICE_ACCOUNT_EMAIL }}
       - name: Set up Google Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
-      - name: Run sync script
+        uses: 'google-github-actions/setup-gcloud@v2'
+      - name: Install dbt dependencies
+        run: dbt deps
+      - name: dbt Build
         run: |
           START_WEEK=${{ inputs.start_week }}
           END_WEEK=${{ inputs.end_week }}
@@ -80,9 +82,8 @@ jobs:
           fi
 
           echo "Using date range: $START_WEEK to $END_WEEK"
-          scp -o StrictHostKeyChecking=no "$GOOGLE_APPLICATION_CREDENTIALS" github@pypacktrends-prod:/tmp/google-credentials.json
-          ssh -o StrictHostKeyChecking=no github@pypacktrends-prod  "START_WEEK='$START_WEEK' END_WEEK='$END_WEEK' bash -c  '
-            cd /home/github/pypacktrends && \
-            git pull && \
-            ./scripts/sync.sh \$START_WEEK \$END_WEEK
-          '"
+          dbt build --target prod --fail-fast --select +pypi_package_downloads_weekly_metrics --vars '{"start_date": $START_WEEK, "end_date": $END_WEEK}'
+      - name: dbt Doc Generate
+        run: dbt docs generate --target prod
+      - name: Sync dbt docs to VPS
+        run: rsync -avz --delete -e "ssh -o StrictHostKeyChecking=no" target/ github@pypacktrends-prod:/home/github/pypacktrends/dbt/target

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -63,11 +63,10 @@ jobs:
           END_WEEK=${{ inputs.end_week }}
 
           if [ -z "$START_WEEK" ]; then
-            START_WEEK=$(date -u -d "last Monday" '+%Y-%m-%d')
+            START_WEEK=$(date -u -d "monday last week" '+%Y-%m-%d')
           fi
-
           if [ -z "$END_WEEK" ]; then
-            END_WEEK=$(date -u -d "last Monday" '+%Y-%m-%d')
+              END_WEEK=$(date -u -d "monday last week" '+%Y-%m-%d')
           fi
 
           # Validate dates

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -63,11 +63,11 @@ jobs:
           END_WEEK=${{ inputs.end_week }}
 
           if [ -z "$START_WEEK" ]; then
-            START_WEEK=$(date -u -d "last Monday - 7 days" '+%Y-%m-%d')
+            START_WEEK=$(date -u -d "last Monday" '+%Y-%m-%d')
           fi
 
           if [ -z "$END_WEEK" ]; then
-            END_WEEK=$(date -u -d "last Monday - 7 days" '+%Y-%m-%d')
+            END_WEEK=$(date -u -d "last Monday" '+%Y-%m-%d')
           fi
 
           # Validate dates

--- a/.github/workflows/weekly-pipeline.yml
+++ b/.github/workflows/weekly-pipeline.yml
@@ -1,0 +1,32 @@
+name: Weekly Pipeline
+on:
+  schedule:
+    - cron: '0 10 * * 1' # Runs at 10:00 UTC on Monday
+  workflow_dispatch:
+    inputs:
+      start_week:
+        description: 'Start week (YYYY-MM-DD Monday Inclusive)'
+        required: false
+        type: string
+        default: ''
+      end_week:
+        description: 'End week (YYYY-MM-DD Monday Inclusive)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  run-dbt:
+    uses: ./.github/workflows/dbt-pypi.yml
+    with:
+      start_week: ${{ github.event.inputs.start_week || (github.event_name == 'schedule' && format('{0}-{1}-{2}', github.event.schedule.year, github.event.schedule.month, github.event.schedule.day)) || '' }}
+      end_week: ${{ github.event.inputs.end_week || (github.event_name == 'schedule' && format('{0}-{1}-{2}', github.event.schedule.year, github.event.schedule.month, github.event.schedule.day)) || '' }}
+    secrets: inherit
+
+  run-sync:
+    needs: run-dbt
+    uses: ./.github/workflows/sync.yml
+    with:
+      start_week: ${{ github.event.inputs.start_week || (github.event_name == 'schedule' && format('{0}-{1}-{2}', github.event.schedule.year, github.event.schedule.month, github.event.schedule.day)) || '' }}
+      end_week: ${{ github.event.inputs.end_week || (github.event_name == 'schedule' && format('{0}-{1}-{2}', github.event.schedule.year, github.event.schedule.month, github.event.schedule.day)) || '' }}
+    secrets: inherit


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix If no start and end week is provided it should default to the last monday but for some reason running on Monday 2024-12-16 put it back to 2024-12-02 so the current day must not count as the "last monday".
- Added dbt-pypi github action to run dbt pypi models
- Added weekly pipeline to run dbt-pypi gha and sync together on a weekly cron schedule
### Additional Context
