### PR TITLE
fix: remove hx-push-url on get graph endpoint

### DIFF
--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -148,5 +148,4 @@ async def get_graph(
             "chart": chart_html,
             "query_params": query_params,
         },
-        headers={"HX-Push-Url": generate_hx_push_url(query_params)},
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

#116 was raised bringing up an issue with the url history causing the back button to not work in Firefox. Turns out I was returning a `HX-Push-Url` on a get request which happens on every load messing up the url history. The `HX-Push-Url` should only be needed on `post` or `delete` requests that would modify the current url.

### Additional Context

N/A