### PR TITLE
fix: time range query param not being updated

### DIFF
--- a/backend/app/static/css/styles.css
+++ b/backend/app/static/css/styles.css
@@ -134,7 +134,7 @@ select[name="time_range"] {
   min-height: 0;
   height: auto;
   background-color: transparent;
-  border: none;
+  border: var(--pico-border-width) solid var(--pico-form-element-border-color);
   border-radius: 0;
   display: inline;
   width: auto;

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -141,6 +141,11 @@ async def get_graph(
     if query_params.packages:
         chart_html = generate_chart(query_params, theme).to_html()
 
+    headers = {}
+
+    if request.headers["HX-Trigger"] == "time-range":
+        headers["HX-Push-Url"] = generate_hx_push_url(query_params)
+
     return templates.TemplateResponse(
         request=request,
         name="fragments/chart.html",
@@ -148,4 +153,5 @@ async def get_graph(
             "chart": chart_html,
             "query_params": query_params,
         },
+        headers=headers,
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug was introduced with PR #117 that was causing the time range URL to not update when user select a new time range. This was because I removed the `HX-Push-URL` forgetting that this endpoint also gets hit in two spots
1. On page load
2. When user selects new time range
3. When user selects or deletes package from the lsit

We only want the push url when it's being triggered by the `time-range`

### Additional Context
