### PR TITLE
fix: remove defer on vega scripts

### DIFF
--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -9,9 +9,9 @@
   <meta name="viewport" content="initial-scale=1, width=device-width" />
   <meta name="description" content="PyPackTrends: Compare and analyze download statistics for Python packages on PyPI. Visualize trends, track popularity, and make informed decisions about Python libraries.">
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
   <script src="https://js.sentry-cdn.com/2f6693a1a57f2f806caa2d34fe9cbd7e.min.js" crossorigin="anonymous"></script>
   <script>
     (function (open, send) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
kept getting sentry errors 'cant find vegaEmbed' my best guess is this is caused by the defer statement on the scripts. Will try removing to see if this fixes it.

### Additional Context
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/1e4db1f8-5f43-4631-a6a5-4ec2cafd3d31" />
