### PR TITLE
feat: add embed option

### DIFF
--- a/backend/app/chart.py
+++ b/backend/app/chart.py
@@ -162,7 +162,7 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
             usermeta={
                 "embedOptions": {
                     "tooltip": {"theme": theme_config[theme]["tooltip"]},
-                    "actions": False,
+                    "actions": True,
                 },
             },
         )

--- a/backend/app/chart.py
+++ b/backend/app/chart.py
@@ -162,7 +162,7 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
             usermeta={
                 "embedOptions": {
                     "tooltip": {"theme": theme_config[theme]["tooltip"]},
-                    "actions": True,
+                    "actions": False,
                 },
             },
         )

--- a/backend/app/static/css/styles.css
+++ b/backend/app/static/css/styles.css
@@ -122,12 +122,6 @@ svg.icon-theme-toggle.moon :first-child path {
 
 #vis {
   width: 100%;
-  opacity: 1;
-  transition: opacity 1s ease-out;
-}
-
-#vis.htmx-added {
-  opacity: 0;
 }
 
 select[name="time_range"] {

--- a/backend/app/templates/fragments/chart.html
+++ b/backend/app/templates/fragments/chart.html
@@ -1,4 +1,5 @@
 {% if query_params.packages | length < 1 %}
+<div id=vis hx-swap-oob="true"></div>
 {% else %}
     <div class="pico">
         <label for="time-range"><strong>Time Range:</strong></label>

--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -83,6 +83,7 @@
 
   <div id="packages-graph" hx-trigger="dataRefresh from:body" hx-get="/packages-graph" hx-swap="innerHTML">
   </div>
+  <div id=vis></div>
 
   <div class="pico">
     <hr />

--- a/backend/app/tests/test_utils.py
+++ b/backend/app/tests/test_utils.py
@@ -1,5 +1,6 @@
 from app.models import QueryParams, TimeRange
 from app.utils import (
+    extract_last_script_tag,
     generate_hx_push_url,
     parse_query_params,
     start_of_week,
@@ -35,3 +36,19 @@ def test_generate_hx_push_url_no_packages() -> None:
     result = generate_hx_push_url(QueryParams(packages=[], time_range=TimeRange()))
     expected_result = "/"
     assert result == expected_result
+
+
+def test_extract_last_script_tag() -> None:
+    html_content = """
+    <html>
+        <script>First script</script>
+        <div>Some content</div>
+        <script>Last script</script>
+    </html>
+    """
+    result = extract_last_script_tag(html_content)
+    assert result == "<script>Last script</script>"
+
+    html_content_no_script = "<html><div>No script here</div></html>"
+    result_no_script = extract_last_script_tag(html_content_no_script)
+    assert result_no_script is None

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -58,3 +58,15 @@ def generate_hx_push_url(query_params: QueryParams) -> str:
         ),
         doseq=True,
     )
+
+
+def extract_last_script_tag(html_content: str) -> str | None:
+    pos = len(html_content)
+    while True:
+        pos = html_content.rfind("<script", 0, pos)
+        if pos == -1:
+            return None
+
+        end_pos = html_content.find("</script>", pos)
+        if end_pos != -1:
+            return html_content[pos : end_pos + len("</script>")]

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -158,3 +158,28 @@ async def get_graph(
         },
         headers=headers,
     )
+
+
+@router.get("/embed", response_class=HTMLResponse)
+async def get_embed(
+    request: Request,
+    time_range: TimeRangeValidValues | None = None,
+) -> HTMLResponse:
+    """Endpoint for embedded charts that can be used in iframes."""
+    query_params = parse_query_params(str(request.url))
+
+    if query_params.error:
+        logger.warning(query_params.error)
+        return HTMLResponse(status_code=422, content=query_params.error)
+
+    theme = request.cookies.get("theme", "light")
+
+    if time_range is not None:
+        query_params.time_range.value = time_range
+
+    if not query_params.packages:
+        return HTMLResponse(content="No packages selected")
+
+    chart_html = generate_chart(query_params, theme).to_html(fullhtml=True)
+
+    return HTMLResponse(content=chart_html)

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Form, Header, Request
 from fastapi.responses import HTMLResponse
@@ -164,6 +164,7 @@ async def get_graph(
 async def get_embed(
     request: Request,
     time_range: TimeRangeValidValues | None = None,
+    theme: Literal["light", "dark"] | None = None,
 ) -> HTMLResponse:
     """Endpoint for embedded charts that can be used in iframes."""
     query_params = parse_query_params(str(request.url))
@@ -172,7 +173,8 @@ async def get_embed(
         logger.warning(query_params.error)
         return HTMLResponse(status_code=422, content=query_params.error)
 
-    theme = request.cookies.get("theme", "light")
+    if not theme:
+        theme = request.cookies.get("theme", "light")
 
     if time_range is not None:
         query_params.time_range.value = time_range

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -8,6 +8,7 @@ from app.core.logger import logger
 from app.core.templates import templates
 from app.models import TimeRangeValidValues
 from app.utils import (
+    extract_last_script_tag,
     generate_hx_push_url,
     parse_query_params,
     validate_package,
@@ -134,12 +135,14 @@ async def get_graph(
 
     theme = request.cookies.get("theme", "light")
     chart_html = ""
+    last_script_tag = ""
 
     if time_range is not None:
         query_params.time_range.value = time_range
 
     if query_params.packages:
-        chart_html = generate_chart(query_params, theme).to_html()
+        chart_html = generate_chart(query_params, theme).to_html(fullhtml=False)
+        last_script_tag = extract_last_script_tag(chart_html) or ""
 
     headers = {}
 
@@ -150,7 +153,7 @@ async def get_graph(
         request=request,
         name="fragments/chart.html",
         context={
-            "chart": chart_html,
+            "chart": last_script_tag,
             "query_params": query_params,
         },
         headers=headers,

--- a/backend/embed.html
+++ b/backend/embed.html
@@ -1,0 +1,7 @@
+<iframe
+    src="http://127.0.0.1:8000/embed?packages=duckdb&packages=polars&time_range=3months&theme=light"
+    width="100%"
+    height="450"
+    frameborder="0"
+>
+</iframe>


### PR DESCRIPTION
## What kind of change does this PR introduce?
There was a feature request #126 to be able to embed charts into other sites via an iframe.

I though for some reason you can do this automatically by added the vega actions button to the graph, I originally avoided this because there was a bug displaying the actions but only after there was second request. 

Turns out this was because of how I was swapping how the entire `<div id=vis>` each time with htmx it ruined the styling of the div. There was also a bunch of extra html that wasn't being returned that I didn't need.

What I changed was to put the `<div id=vis>` outside of original div and put it below. I then parse the html generated from altair and grab only the last script tag which is all that's needed to update the chart.

```html
  <div id="packages-graph" hx-trigger="dataRefresh from:body" hx-get="/packages-graph" hx-swap="innerHTML">
  </div>
  <div id=vis></div>
``` 

To ensure the graph gets removed when you deselect all packages I added a [hx-swab-oob](https://htmx.org/attributes/hx-swap-oob/) to update the div with nothing.

In doing this I accidentally broke the transition of the graph in and out the page, but it turns out I think it feels much snappier without the transition so I didn't bother fixing it and removed the related css.

All this work to find out the actions button doesn't give the user the ability to embed the chart only allows the following:
![image](https://github.com/user-attachments/assets/8160f6b8-0bb9-48d8-99f9-4939a4e1a29b)

I decided to leave it off but get the rest of the changes incase I ever want to bring it back.

Instead what I did was implement and `embed` endpoint which returns back the full html needed to render the graph. It's very similar to the to the `packages-graph` endpoint.

Now users can create an iframe like:
```html
<iframe
    src="http://127.0.0.1:8000/embed?packages=duckdb&packages=polars&time_range=3months"
    width="100%"
    height="450"
    frameborder="0">
</iframe>
```

which would look like
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/a96384c7-cf2b-40ee-b0b8-0b6fc56c54e0" />

