### PR TITLE
feat: add percent of total downloads checkbox

### DIFF
--- a/backend/app/chart.py
+++ b/backend/app/chart.py
@@ -66,6 +66,7 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
                 package_name,
                 package_downloaded_week,
                 downloads,
+                downloads * 1.0 / nullif(sum(downloads) over(partition by package_downloaded_week), 0) as percentage_of_total_downloads,
                 cumulative_downloads,
                 weeks_since_first_distribution
             from
@@ -85,6 +86,7 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
             "package",
             "week",
             "downloads",
+            "percentage_of_total_downloads",
             "cumulative_downloads",
             "weeks_since_first_distribution",
         ],
@@ -93,32 +95,44 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
 
     highlight = alt.selection_point(on="pointerover", fields=["package"], nearest=True)
 
+    x_weeks_since_first_release = dict(
+        shorthand="weeks_since_first_distribution:Q",
+        title="Weeks Since First Release",
+        format=",",
+    )
+
+    x_week = dict(
+        shorthand="week:T",
+        title="",
+        format="%Y-%m-%d",
+    )
+
     if query_params.time_range.value == "allTimeCumulativeAlignTimeline":
-        x = dict(
-            shorthand="weeks_since_first_distribution:Q",
-            title="Weeks Since First Release",
-            format=",",
-        )
+        x = x_weeks_since_first_release
     else:
-        x = dict(
-            shorthand="week:T",
-            title="",
-            format="%Y-%m-%d",
-        )
+        x = x_week
+
+    y_cumulative_downloads = dict(
+        shorthand="cumulative_downloads:Q", title="Cumulative Downloads", format=","
+    )
+
+    y_perecent_of_total = dict(
+        shorthand="percentage_of_total_downloads:Q",
+        title="Percent of Total Downloads",
+        format=".2%",
+    )
+
+    y_weekly_downloads = dict(shorthand="downloads:Q", title="Downloads", format=",")
 
     if query_params.time_range.value in (
         "allTimeCumulative",
         "allTimeCumulativeAlignTimeline",
     ):
-        y = dict(
-            shorthand="cumulative_downloads:Q",
-            title="Cumulative Downloads",
-        )
+        y = y_cumulative_downloads
+    elif query_params.show_percentage == "on":
+        y = y_perecent_of_total
     else:
-        y = dict(
-            shorthand="downloads:Q",
-            title="Downloads",
-        )
+        y = y_weekly_downloads
 
     base = alt.Chart(df).encode(
         x=alt.X(
@@ -129,13 +143,23 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
         y=alt.Y(
             y["shorthand"],
             title=y["title"],
-            axis=alt.Axis(tickCount=3, labelFontSize=14),
+            axis=alt.Axis(
+                tickCount=3,
+                labelFontSize=14,
+                format=".0%" if query_params.show_percentage == "on" else alt.Undefined,
+            ),
+            scale=alt.Scale(domain=[0, 1])
+            if query_params.show_percentage == "on"
+            else alt.Undefined,
         ),
         color="package:N",
         tooltip=[
             alt.Tooltip("package:N"),
-            alt.Tooltip(**x),
-            alt.Tooltip(**y, format=","),
+            alt.Tooltip(**x_week),
+            alt.Tooltip(**x_weeks_since_first_release),
+            alt.Tooltip(**y_weekly_downloads),
+            alt.Tooltip(**y_cumulative_downloads),
+            alt.Tooltip(**y_perecent_of_total),
         ],
     )
 

--- a/backend/app/chart.py
+++ b/backend/app/chart.py
@@ -124,12 +124,15 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
 
     y_weekly_downloads = dict(shorthand="downloads:Q", title="Downloads", format=",")
 
-    if query_params.time_range.value in (
+    is_cumulative = query_params.time_range.value in (
         "allTimeCumulative",
         "allTimeCumulativeAlignTimeline",
-    ):
+    )
+    show_percentage = query_params.show_percentage == "on" and not is_cumulative
+
+    if is_cumulative:
         y = y_cumulative_downloads
-    elif query_params.show_percentage == "on":
+    elif show_percentage:
         y = y_perecent_of_total
     else:
         y = y_weekly_downloads
@@ -146,20 +149,18 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
             axis=alt.Axis(
                 tickCount=3,
                 labelFontSize=14,
-                format=".0%" if query_params.show_percentage == "on" else alt.Undefined,
+                format=".0%" if show_percentage else alt.Undefined,
             ),
-            scale=alt.Scale(domain=[0, 1])
-            if query_params.show_percentage == "on"
-            else alt.Undefined,
+            scale=alt.Scale(domain=[0, 1]) if show_percentage else alt.Undefined,
         ),
         color="package:N",
         tooltip=[
             alt.Tooltip("package:N"),
             alt.Tooltip(**x_week),
-            alt.Tooltip(**x_weeks_since_first_release),
             alt.Tooltip(**y_weekly_downloads),
             alt.Tooltip(**y_cumulative_downloads),
             alt.Tooltip(**y_perecent_of_total),
+            alt.Tooltip(**x_weeks_since_first_release),
         ],
     )
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -55,4 +55,5 @@ class TimeRange(BaseModel):
 class QueryParams(BaseModel):
     packages: list[str] = []
     time_range: TimeRange = TimeRange(value="3months")
+    show_percentage: Literal["on", "off"] = "off"
     error: str | None = None

--- a/backend/app/templates/fragments/chart.html
+++ b/backend/app/templates/fragments/chart.html
@@ -1,10 +1,10 @@
 {% if query_params.packages | length < 1 %}
 <div id=vis hx-swap-oob="true"></div>
 {% else %}
-    <div class="pico">
-        <label for="time-range"><strong>Time Range:</strong></label>
+    <div class="pico" style="display: flex;">
+        <label for="time-range" style="margin-right: 10px;"><strong>Time Range:</strong></label>
         <select name="time_range" id="time-range" hx-trigger="change" hx-get="/packages-graph" hx-target="#packages-graph"
-            hx-swap="innerHTML">
+            hx-swap="innerHTML" hx-include="[name='show_percentage']" style="margin-right: 20px;">
             <option value="1month" {% if query_params.time_range.value == '1month' %}selected{% endif %}>1 month</option>
             <option value="3months" {% if query_params.time_range.value == '3months' %}selected{% endif %}>3 months</option>
             <option value="6months" {% if query_params.time_range.value == '6months' %}selected{% endif %}>6 months</option>
@@ -15,6 +15,12 @@
             <option value="allTimeCumulative" {% if query_params.time_range.value == 'allTimeCumulative' %}selected{% endif %}>All Time Cumulative</option>
             <option value="allTimeCumulativeAlignTimeline" {% if query_params.time_range.value == 'allTimeCumulativeAlignTimeline' %}selected{% endif %}>All Time Cumulative (Align Timeline)</option>
         </select>
+        <label for="show-percentage">
+            <strong>Show as % of Total</strong>
+            <input type="checkbox" id="show-percentage" name="show_percentage" {% if query_params.show_percentage == 'on' %}checked{%endif %}
+                hx-get="/packages-graph" hx-target="#packages-graph" hx-trigger="change" hx-include="[name='time_range']"
+            >
+        </label>
     </div>
     {{ chart | safe }}
 {% endif %}

--- a/backend/app/templates/fragments/chart.html
+++ b/backend/app/templates/fragments/chart.html
@@ -15,12 +15,15 @@
             <option value="allTimeCumulative" {% if query_params.time_range.value == 'allTimeCumulative' %}selected{% endif %}>All Time Cumulative</option>
             <option value="allTimeCumulativeAlignTimeline" {% if query_params.time_range.value == 'allTimeCumulativeAlignTimeline' %}selected{% endif %}>All Time Cumulative (Align Timeline)</option>
         </select>
+        {% if query_params.time_range.value not in ['allTimeCumulative', 'allTimeCumulativeAlignTimeline'] %}
         <label for="show-percentage">
             <strong>Show as % of Total</strong>
-            <input type="checkbox" id="show-percentage" name="show_percentage" {% if query_params.show_percentage == 'on' %}checked{%endif %}
-                hx-get="/packages-graph" hx-target="#packages-graph" hx-trigger="change" hx-include="[name='time_range']"
+            <input type="checkbox" id="show-percentage" name="show_percentage"
+            hx-get="/packages-graph" hx-target="#packages-graph" hx-trigger="change" hx-include="[name='time_range']"
+            {% if query_params.show_percentage == 'on' %}checked{%endif %}
             >
         </label>
+        {% endif %}
     </div>
     {{ chart | safe }}
 {% endif %}

--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -12,7 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
-  <script src="https://js.sentry-cdn.com/2f6693a1a57f2f806caa2d34fe9cbd7e.min.js" crossorigin="anonymous"></script>
+  <!-- <script src="https://js.sentry-cdn.com/2f6693a1a57f2f806caa2d34fe9cbd7e.min.js" crossorigin="anonymous"></script>
   <script>
     (function (open, send) {
       XMLHttpRequest.prototype.open = function (method, url, async, user, password) {
@@ -33,7 +33,7 @@
       api_host: 'https://us.i.posthog.com',
       person_profiles: 'identified_only'
     });
-  </script>
+  </script> -->
   <link rel="icon"
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐍</text></svg>">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.conditional.min.css" />

--- a/backend/app/tests/test_utils.py
+++ b/backend/app/tests/test_utils.py
@@ -26,9 +26,13 @@ def test_parse_query_params() -> None:
 
 def test_generate_hx_push_url_packages() -> None:
     result = generate_hx_push_url(
-        QueryParams(packages=["duckdb", "pandas"], time_range=TimeRange())
+        QueryParams(
+            packages=["duckdb", "pandas"], time_range=TimeRange(), show_percentage="off"
+        )
     )
-    expected_result = "?packages=duckdb&packages=pandas&time_range=3months"
+    expected_result = (
+        "?packages=duckdb&packages=pandas&time_range=3months&show_percentage=off"
+    )
     assert result == expected_result
 
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Literal, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from pydantic import ValidationError
@@ -43,7 +43,12 @@ def parse_query_params(url: str) -> QueryParams:
         time_range = TimeRange(
             value=cast(TimeRangeValidValues, qs.get("time_range", ["3months"])[0])
         )
-        return QueryParams(time_range=time_range, packages=packages)
+        show_percentage = cast(
+            Literal["on", "off"], qs.get("show_percentage", ["off"])[0]
+        )
+        return QueryParams(
+            time_range=time_range, packages=packages, show_percentage=show_percentage
+        )
     except ValidationError as e:
         return QueryParams(error=str(e))
 
@@ -55,6 +60,7 @@ def generate_hx_push_url(query_params: QueryParams) -> str:
         dict(
             packages=[package for package in query_params.packages],
             time_range=query_params.time_range.value,
+            show_percentage=query_params.show_percentage,
         ),
         doseq=True,
     )

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -169,6 +169,7 @@ async def get_embed(
     request: Request,
     time_range: TimeRangeValidValues | None = None,
     theme: Literal["light", "dark"] | None = None,
+    show_percentage: Literal["on", "off"] = "off",
 ) -> HTMLResponse:
     """Endpoint for embedded charts that can be used in iframes."""
     query_params = parse_query_params(str(request.url))
@@ -182,6 +183,9 @@ async def get_embed(
 
     if time_range is not None:
         query_params.time_range.value = time_range
+
+    if show_percentage is not None:
+        query_params.show_percentage = show_percentage
 
     if not query_params.packages:
         return HTMLResponse(content="No packages selected")

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -126,6 +126,7 @@ async def get_graph(
     request: Request,
     url: Annotated[str, Header(alias="HX-Current-URL")],
     time_range: TimeRangeValidValues | None = None,
+    show_percentage: Literal["on", "off"] = "off",
 ) -> HTMLResponse:
     query_params = parse_query_params(url)
 
@@ -140,13 +141,16 @@ async def get_graph(
     if time_range is not None:
         query_params.time_range.value = time_range
 
+    if show_percentage is not None:
+        query_params.show_percentage = show_percentage
+
     if query_params.packages:
         chart_html = generate_chart(query_params, theme).to_html(fullhtml=False)
         last_script_tag = extract_last_script_tag(chart_html) or ""
 
     headers = {}
 
-    if request.headers["HX-Trigger"] == "time-range":
+    if request.headers["HX-Trigger"] in ["time-range", "show-percentage"]:
         headers["HX-Push-Url"] = generate_hx_push_url(query_params)
 
     return templates.TemplateResponse(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature request #127 wanted the ability to show the downloads as a percent of total downloads to help normalize seasonality such as Christmas.

This PR adds a checkbox for all time periods that are **not** cumulative that can be checked which adds a query param show_percentages=on (it's off by default, side note I guess you can't have a bool in a query param? The checkbox defaults to adding "on", I thought this was weird).

I have also changed the tooltip to include all stats no matter what.

### Additional Context
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/f6ec358e-a98d-4566-89d5-13ba1979c0a2" />

