### PR TITLE
fix: show pct checkbox gets deselected on refresh and package list actions

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -55,5 +55,5 @@ class TimeRange(BaseModel):
 class QueryParams(BaseModel):
     packages: list[str] = []
     time_range: TimeRange = TimeRange(value="3months")
-    show_percentage: Literal["on", "off"] = "off"
+    show_percentage: Literal["on"] | None = None
     error: str | None = None

--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -81,7 +81,9 @@
   </div>
 
 
-  <div id="packages-graph" hx-trigger="dataRefresh from:body" hx-get="/packages-graph" hx-swap="innerHTML">
+  <div id="packages-graph" hx-trigger="dataRefresh from:body" hx-get="/packages-graph" hx-swap="innerHTML"
+  hx-include="[name='time_range'], [name='show_percentage']"
+  >
   </div>
   <div id=vis></div>
 

--- a/backend/app/tests/test_utils.py
+++ b/backend/app/tests/test_utils.py
@@ -18,7 +18,9 @@ def test_parse_query_params() -> None:
     result = parse_query_params(url)
 
     expected_result = QueryParams(
-        packages=["duckdb", "pandas"], time_range=TimeRange(value="1month")
+        packages=["duckdb", "pandas"],
+        time_range=TimeRange(value="1month"),
+        show_percentage=None,
     )
     assert result.packages == expected_result.packages
     assert result.time_range.value == expected_result.time_range.value
@@ -27,17 +29,17 @@ def test_parse_query_params() -> None:
 def test_generate_hx_push_url_packages() -> None:
     result = generate_hx_push_url(
         QueryParams(
-            packages=["duckdb", "pandas"], time_range=TimeRange(), show_percentage="off"
+            packages=["duckdb", "pandas"], time_range=TimeRange(), show_percentage=None
         )
     )
-    expected_result = (
-        "?packages=duckdb&packages=pandas&time_range=3months&show_percentage=off"
-    )
+    expected_result = "?packages=duckdb&packages=pandas&time_range=3months"
     assert result == expected_result
 
 
 def test_generate_hx_push_url_no_packages() -> None:
-    result = generate_hx_push_url(QueryParams(packages=[], time_range=TimeRange()))
+    result = generate_hx_push_url(
+        QueryParams(packages=[], time_range=TimeRange(), show_percentage=None)
+    )
     expected_result = "/"
     assert result == expected_result
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -43,9 +43,7 @@ def parse_query_params(url: str) -> QueryParams:
         time_range = TimeRange(
             value=cast(TimeRangeValidValues, qs.get("time_range", ["3months"])[0])
         )
-        show_percentage = cast(
-            Literal["on", "off"], qs.get("show_percentage", ["off"])[0]
-        )
+        show_percentage = cast(Literal["on"], qs.get("show_percentage", [None])[0])
         return QueryParams(
             time_range=time_range, packages=packages, show_percentage=show_percentage
         )
@@ -56,14 +54,13 @@ def parse_query_params(url: str) -> QueryParams:
 def generate_hx_push_url(query_params: QueryParams) -> str:
     if not query_params.packages:
         return "/"
-    return "?" + urlencode(
-        dict(
-            packages=[package for package in query_params.packages],
-            time_range=query_params.time_range.value,
-            show_percentage=query_params.show_percentage,
-        ),
-        doseq=True,
-    )
+    params = {
+        "packages": [package for package in query_params.packages],
+        "time_range": query_params.time_range.value,
+    }
+    if query_params.show_percentage is not None:
+        params["show_percentage"] = [query_params.show_percentage]
+    return "?" + urlencode(params, doseq=True)
 
 
 def extract_last_script_tag(html_content: str) -> str | None:

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -126,7 +126,7 @@ async def get_graph(
     request: Request,
     url: Annotated[str, Header(alias="HX-Current-URL")],
     time_range: TimeRangeValidValues | None = None,
-    show_percentage: Literal["on", "off"] = "off",
+    show_percentage: Literal["on"] | None = None,
 ) -> HTMLResponse:
     query_params = parse_query_params(url)
 
@@ -141,7 +141,10 @@ async def get_graph(
     if time_range is not None:
         query_params.time_range.value = time_range
 
-    if show_percentage is not None:
+    if (
+        show_percentage is not None
+        or request.headers["HX-Trigger"] == "show-percentage"
+    ):
         query_params.show_percentage = show_percentage
 
     if query_params.packages:
@@ -169,7 +172,7 @@ async def get_embed(
     request: Request,
     time_range: TimeRangeValidValues | None = None,
     theme: Literal["light", "dark"] | None = None,
-    show_percentage: Literal["on", "off"] = "off",
+    show_percentage: Literal["on"] | None = None,
 ) -> HTMLResponse:
     """Endpoint for embedded charts that can be used in iframes."""
     query_params = parse_query_params(str(request.url))


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug was introduced in #132 when adding the check box to display the downloads as percent of total. On page refresh, or any actions made on the package list the the show pct checkbox wasn't sticking this is because of the weirdness with the checkbox value is "on" when change to selected but when changed to off it doesn't have any value so essentially a python `None`. This means it requires slightly different logic because before I was basically keeping what's was in the current URL unless new ones were added to the request. That doesn't work here because the absent of the show_percentage can mean something but only if that was triggered by the checkbox otherwise we can keep the same value as before.

### Additional Context
