### PR TITLE
chore: increase dbt max bytes billed

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -66,6 +66,6 @@ jobs:
       - name: Clone dbt incremental models
         run: dbt clone --target ci --select state:modified+,config.materialized:incremental,state:old --state ./prod-run-artifacts
       - name: dbt Build
-        run: dbt build --target ci --fail-fast --select state:modified+ --defer --state ./prod-run-artifacts --exclude dbt_artifacts
+        run: dbt build --target ci --fail-fast --select state:modified.body+ --defer --state ./prod-run-artifacts --exclude dbt_artifacts
       - name: dbt Doc Generate
         run: dbt docs generate --target ci --exclude dbt_artifacts

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -28,4 +28,4 @@ pypacktrends:
       priority: interactive
       threads: 4
       timeout_seconds: 600
-      maximum_bytes_billed: 300000000000
+      maximum_bytes_billed: 305000000000


### PR DESCRIPTION
## What kind of change does this PR introduce?
Weekly pipeline is failing because it's hitting the max bytes billed of 30GB. BigQuery's estimated bytes scanned can overestimate sometimes so increasing it a bit.j

### Additional Context
