### PR TITLE
fix: change chart interpolation method to monotone

### DIFF
--- a/backend/app/chart.py
+++ b/backend/app/chart.py
@@ -167,7 +167,7 @@ def generate_chart(query_params: QueryParams, theme: str) -> alt.Chart:
     points = base.mark_circle().encode(opacity=alt.value(0)).add_params(highlight)
 
     lines = base.mark_line(
-        interpolate="natural", strokeWidth=4, strokeCap="round"
+        interpolate="monotone", strokeWidth=4, strokeCap="round"
     ).encode(
         size=alt.when(~highlight).then(alt.value(2)).otherwise(alt.value(3)),
         color=alt.Color(


### PR DESCRIPTION
## What kind of change does this PR introduce?
Chart interpolation caused the line to dip below zero when that's not possible, change the method from natural to monotone 

### Additional Context
**Before**
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/51ff3332-7ec9-4490-8c46-75366601b246" />

**After**
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/19dee247-11a5-4f4e-a751-76496345b05e" />
