### PR TITLE
chore: increase max bytes billed

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -28,4 +28,4 @@ pypacktrends:
       priority: interactive
       threads: 4
       timeout_seconds: 600
-      maximum_bytes_billed: 305000000000
+      maximum_bytes_billed: 400000000000


### PR DESCRIPTION
## What kind of change does this PR introduce?
Weekly sync is failing because the query is slightly more than my max bytes threshhold. Increasing to 400GB 

### Additional Context
