### PR TITLE
fix: change from error to warn for package removal

### DIFF
--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -7,11 +7,13 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta name="description" content="PyPackTrends: Compare and analyze download statistics for Python packages on PyPI. Visualize trends, track popularity, and make informed decisions about Python libraries.">
+  <meta name="description"
+    content="PyPackTrends: Compare and analyze download statistics for Python packages on PyPI. Visualize trends, track popularity, and make informed decisions about Python libraries.">
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+  {% if environment == "prod" %}
   <script>
     (function (open, send) {
       XMLHttpRequest.prototype.open = function (method, url, async, user, password) {
@@ -33,6 +35,7 @@
       person_profiles: 'identified_only'
     });
   </script>
+  {% endif %}
   <link rel="icon"
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐍</text></svg>">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.conditional.min.css" />

--- a/backend/app/views/routes/home.py
+++ b/backend/app/views/routes/home.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
+from app.core.config import settings
 from app.core.logger import logger
 from app.core.templates import templates
 
@@ -14,7 +15,9 @@ async def home_view(request: Request) -> HTMLResponse:
     )
     theme = request.cookies.get("theme", "light")
     return templates.TemplateResponse(
-        request=request, name="pages/home.html", context={"theme": theme}
+        request=request,
+        name="pages/home.html",
+        context={"theme": theme, "environment": settings.ENVIRONMENT},
     )
 
 

--- a/backend/app/views/routes/packages.py
+++ b/backend/app/views/routes/packages.py
@@ -102,12 +102,11 @@ async def delete_package(
         logger.warning(query_params.error)
         return HTMLResponse(status_code=422, content=query_params.error)
 
-    try:
+    if package_name in query_params.packages:
         query_params.packages.remove(package_name)
         logger.info(f"Successfully removed package: {package_name}")
-    except ValueError:
-        logger.error(f"Failed to remove package {package_name} - not found in list")
-        raise
+    else:
+        logger.warning(f"Package {package_name} not found in current URL state")
 
     colors = generate_altair_colors(len(query_params.packages))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
**Bug Fix** - Graceful handling of race condition in package deletion

Kept getting sentry alerts on failures for trying to delete a package that is not currently selected. Root cause for this issue is unknown because the Hx-Current-Url should have the state for all selected packages. The only way a DELETE request to the `/package-list` endpoint can happen is by hitting the X on the package button which would imply that it SHOULD be in the Hx-Current-Url.

My best guess is that there is a deeper issue with how I'm managing the state with `HX-Push-Url` or it's a result of some fast user interactions causing race conditions between HTMX requests.

### Changes Made
- Replaced `try/except ValueError` with graceful conditional check in `delete_package` endpoint
- Changed from raising exceptions to logging warnings when package not found in URL state
- Function now continues execution and returns current package list state instead of crashing

### Additional Context
This race condition likely occurs when:
1. User rapidly interacts with the UI (adding/removing packages, changing filters)
2. Multiple HTMX requests fire simultaneously 
3. URL state gets updated by one request while another is still processing
4. DOM elements become stale but still trigger delete requests

Rather than trying to solve the complex state synchronization issue, this fix ensures the user experience remains smooth by gracefully handling the edge case. The warning logs will help monitor how frequently this occurs without breaking the application.

**Before**: Application would crash with 500 error when trying to delete non-existent package  
**After**: Application logs the inconsistency and returns the correct current package