### PR TITLE
chore: change max bytes billed to 750GB

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -28,4 +28,4 @@ pypacktrends:
       priority: interactive
       threads: 4
       timeout_seconds: 600
-      maximum_bytes_billed: 400000000000
+      maximum_bytes_billed: 750000000000


### PR DESCRIPTION
## What kind of change does this PR introduce?
Increase max bytes billed so weekly pipeline doesn't fail

### Additional Context
