### PR TITLE
chore: bump max bytes billed

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -28,4 +28,4 @@ pypacktrends:
       priority: interactive
       threads: 4
       timeout_seconds: 600
-      maximum_bytes_billed: 750000000000
+      maximum_bytes_billed: 1000000000000


### PR DESCRIPTION
## What kind of change does this PR introduce?
Increasing the max bytes billed

### Additional Context
weekly github action is failing because we are hitting this limit