### PR TITLE
fix: vega cdn urls

### DIFF
--- a/backend/app/templates/pages/home.html
+++ b/backend/app/templates/pages/home.html
@@ -10,9 +10,9 @@
   <meta name="description"
     content="PyPackTrends: Compare and analyze download statistics for Python packages on PyPI. Visualize trends, track popularity, and make informed decisions about Python libraries.">
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega@5/build/vega.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5/build/vega-lite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js"></script>
   {% if environment == "prod" %}
   <script>
     (function (open, send) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

For some reason these vega urls for jsdelivr are no longer valid
